### PR TITLE
[hydra-java] In README, mention JAVA_HOME in build instructions

### DIFF
--- a/hydra-java/README.md
+++ b/hydra-java/README.md
@@ -7,5 +7,5 @@ This package contains Hydra's Java API and Java sources specifically.
 
 ## Build
 
-Build the Java project with `./gradlew build`, or publish the resulting JAR to your local Maven repository with `./gradlew publishToMavenLocal`.
+Build the Java project with `./gradlew build`, or publish the resulting JAR to your local Maven repository with `./gradlew publishToMavenLocal`. This project requires Java 11 so you may need to set the `JAVA_HOME` environment variable accordingly: `JAVA_HOME=/path/to/java11/installation ./gradlew build`.
 


### PR DESCRIPTION
I had to build with a `JAVA_HOME` set to a Java 11 directory (my default was set to Java 8). Adding it to the README will save future contributors a few minutes of debugging a failed build.