### PR TITLE
Experimental bundling of Java primitive function implementations with their metadata

### DIFF
--- a/hydra-java/src/gen-main/java/hydra/basics/Basics.java
+++ b/hydra-java/src/gen-main/java/hydra/basics/Basics.java
@@ -341,7 +341,7 @@ public interface Basics {
     new hydra.mantle.LiteralVariant.String_());
   
   static java.util.function.Function<String, hydra.core.Name> qname(hydra.module.Namespace ns) {
-    return name -> new hydra.core.Name(hydra.lib.strings.Strings.cat(java.util.Arrays.asList(
+    return name -> new hydra.core.Name(hydra.lib.strings.Cat.apply(java.util.Arrays.asList(
       ((ns)).value,
       ".",
       (name))));

--- a/hydra-java/src/gen-main/java/hydra/printing/Printing.java
+++ b/hydra-java/src/gen-main/java/hydra/printing/Printing.java
@@ -5,13 +5,13 @@ package hydra.printing;
  */
 public interface Printing {
   static String describeFloatType(hydra.core.FloatType t) {
-    return hydra.lib.strings.Strings.cat(java.util.Arrays.asList(
+    return hydra.lib.strings.Cat.apply(java.util.Arrays.asList(
       hydra.printing.Printing.describePrecision(hydra.basics.Basics.floatTypePrecision((t))),
       " floating-point numbers"));
   }
   
   static String describeIntegerType(hydra.core.IntegerType t) {
-    return hydra.lib.strings.Strings.cat(java.util.Arrays.asList(
+    return hydra.lib.strings.Cat.apply(java.util.Arrays.asList(
       hydra.printing.Printing.describePrecision(hydra.basics.Basics.integerTypePrecision((t))),
       " integers"));
   }
@@ -54,7 +54,7 @@ public interface Printing {
       
       @Override
       public String visit(hydra.mantle.Precision.Bits instance) {
-        return hydra.lib.strings.Strings.cat(java.util.Arrays.asList(
+        return hydra.lib.strings.Cat.apply(java.util.Arrays.asList(
           hydra.lib.literals.Literals.showInt32((instance.value)),
           "-bit"));
       }
@@ -65,7 +65,7 @@ public interface Printing {
     return ((typ)).accept(new hydra.core.Type.Visitor<String>() {
       @Override
       public String visit(hydra.core.Type.Annotated instance) {
-        return hydra.lib.strings.Strings.cat(java.util.Arrays.asList(
+        return hydra.lib.strings.Cat.apply(java.util.Arrays.asList(
           "annotated ",
           hydra.printing.Printing.describeType((hydra.core.Type<M>) (((instance.value)).subject))));
       }
@@ -82,16 +82,16 @@ public interface Printing {
       
       @Override
       public String visit(hydra.core.Type.Element instance) {
-        return hydra.lib.strings.Strings.cat(java.util.Arrays.asList(
+        return hydra.lib.strings.Cat.apply(java.util.Arrays.asList(
           "elements containing ",
           hydra.printing.Printing.describeType((instance.value))));
       }
       
       @Override
       public String visit(hydra.core.Type.Function instance) {
-        return hydra.lib.strings.Strings.cat(java.util.Arrays.asList(
-          hydra.lib.strings.Strings.cat(java.util.Arrays.asList(
-            hydra.lib.strings.Strings.cat(java.util.Arrays.asList(
+        return hydra.lib.strings.Cat.apply(java.util.Arrays.asList(
+          hydra.lib.strings.Cat.apply(java.util.Arrays.asList(
+            hydra.lib.strings.Cat.apply(java.util.Arrays.asList(
               "functions from ",
               hydra.printing.Printing.describeType((hydra.core.Type<M>) (((instance.value)).domain)))),
             " to ")),
@@ -105,16 +105,16 @@ public interface Printing {
       
       @Override
       public String visit(hydra.core.Type.List instance) {
-        return hydra.lib.strings.Strings.cat(java.util.Arrays.asList(
+        return hydra.lib.strings.Cat.apply(java.util.Arrays.asList(
           "lists of ",
           hydra.printing.Printing.describeType((instance.value))));
       }
       
       @Override
       public String visit(hydra.core.Type.Map instance) {
-        return hydra.lib.strings.Strings.cat(java.util.Arrays.asList(
-          hydra.lib.strings.Strings.cat(java.util.Arrays.asList(
-            hydra.lib.strings.Strings.cat(java.util.Arrays.asList(
+        return hydra.lib.strings.Cat.apply(java.util.Arrays.asList(
+          hydra.lib.strings.Cat.apply(java.util.Arrays.asList(
+            hydra.lib.strings.Cat.apply(java.util.Arrays.asList(
               "maps from ",
               hydra.printing.Printing.describeType((hydra.core.Type<M>) (((instance.value)).keys)))),
             " to ")),
@@ -123,14 +123,14 @@ public interface Printing {
       
       @Override
       public String visit(hydra.core.Type.Wrap instance) {
-        return hydra.lib.strings.Strings.cat(java.util.Arrays.asList(
+        return hydra.lib.strings.Cat.apply(java.util.Arrays.asList(
           "alias for ",
           ((instance.value)).value));
       }
       
       @Override
       public String visit(hydra.core.Type.Optional instance) {
-        return hydra.lib.strings.Strings.cat(java.util.Arrays.asList(
+        return hydra.lib.strings.Cat.apply(java.util.Arrays.asList(
           "optional ",
           hydra.printing.Printing.describeType((instance.value))));
       }
@@ -147,14 +147,14 @@ public interface Printing {
       
       @Override
       public String visit(hydra.core.Type.Set instance) {
-        return hydra.lib.strings.Strings.cat(java.util.Arrays.asList(
+        return hydra.lib.strings.Cat.apply(java.util.Arrays.asList(
           "sets of ",
           hydra.printing.Printing.describeType((instance.value))));
       }
       
       @Override
       public String visit(hydra.core.Type.Stream instance) {
-        return hydra.lib.strings.Strings.cat(java.util.Arrays.asList(
+        return hydra.lib.strings.Cat.apply(java.util.Arrays.asList(
           "streams of ",
           hydra.printing.Printing.describeType((instance.value))));
       }

--- a/hydra-java/src/main/java/hydra/PrimitiveFunction.java
+++ b/hydra-java/src/main/java/hydra/PrimitiveFunction.java
@@ -1,0 +1,13 @@
+package hydra;
+
+import hydra.core.Name;
+import hydra.core.Term;
+import hydra.dsl.Terms;
+
+public abstract class PrimitiveFunction<M> {
+    public abstract Name name();
+
+    public Term<M> term() {
+        return Terms.primitive(name()); 
+    }
+}

--- a/hydra-java/src/main/java/hydra/dsl/prims/Strings.java
+++ b/hydra-java/src/main/java/hydra/dsl/prims/Strings.java
@@ -1,0 +1,26 @@
+package hydra.dsl.prims;
+
+import hydra.core.Term;
+import hydra.lib.strings.*;
+
+public interface Strings {
+    static <M> Term<M> cat() {
+        return new Cat().term();
+    }
+
+    static <M> Term<M> length() {
+        return new Length().term();
+    }
+
+    static <M> Term<M> splitOn() {
+        return new SplitOn().term();
+    }
+
+    static <M> Term<M> toLower() {
+        return new ToLower().term();
+    }
+
+    static <M> Term<M> toUpper() {
+        return new ToUpper().term();
+    }
+}

--- a/hydra-java/src/main/java/hydra/lib/strings/Cat.java
+++ b/hydra-java/src/main/java/hydra/lib/strings/Cat.java
@@ -1,0 +1,15 @@
+package hydra.lib.strings;
+
+import hydra.core.Name;
+import hydra.PrimitiveFunction;
+import java.util.List;
+
+public class Cat<M> extends PrimitiveFunction<M> {
+    public Name name() {
+        return new Name("hydra/lib/strings.cat");
+    }
+
+    public static String apply(List<String> args) {
+        return String.join("", args);
+    }
+}

--- a/hydra-java/src/main/java/hydra/lib/strings/Length.java
+++ b/hydra-java/src/main/java/hydra/lib/strings/Length.java
@@ -1,0 +1,14 @@
+package hydra.lib.strings;
+
+import hydra.core.Name;
+import hydra.PrimitiveFunction;
+
+public class Length<M> extends PrimitiveFunction<M> {
+    public Name name() {
+        return new Name("hydra/lib/strings.length");
+    }
+
+    public static int apply(String s) {
+        return s.length();
+    }
+}

--- a/hydra-java/src/main/java/hydra/lib/strings/SplitOn.java
+++ b/hydra-java/src/main/java/hydra/lib/strings/SplitOn.java
@@ -1,19 +1,17 @@
 package hydra.lib.strings;
 
-import java.util.ArrayList;
+import hydra.core.Name;
+import hydra.PrimitiveFunction;
 import java.util.List;
+import java.util.ArrayList;
 
-public interface Strings {
-    static String cat(List<String> args) {
-        return String.join("", args);
-    }
-
-    static int length(String s) {
-        return s.length();
+public class SplitOn<M> extends PrimitiveFunction<M> {
+    public Name name() {
+        return new Name("hydra/lib/strings.splitOn");
     }
 
     // Note: the substring is not interpreted as a regular expression; it is simply a literal string. See Haskell's Data.List.Split.
-    static List<String> splitOn(String delim, String string) {
+    public static List<String> apply(String delim, String string) {
         List<String> parts = new ArrayList<>();
 
         if (delim.length() == 0) {
@@ -49,13 +47,5 @@ public interface Strings {
         }
 
         return parts;
-    }
-
-    static String toLower(String upper) {
-        return upper.toLowerCase(); // TODO: Java's built-in behavior may not agree with that of Haskell or other host languages
-    }
-
-    static String toUpper(String lower) {
-        return lower.toUpperCase(); // TODO: Java's built-in behavior may not agree with that of Haskell or other host languages
     }
 }

--- a/hydra-java/src/main/java/hydra/lib/strings/ToLower.java
+++ b/hydra-java/src/main/java/hydra/lib/strings/ToLower.java
@@ -1,0 +1,14 @@
+package hydra.lib.strings;
+
+import hydra.core.Name;
+import hydra.PrimitiveFunction;
+
+public class ToLower<M> extends PrimitiveFunction<M> {
+    public Name name() {
+        return new Name("hydra/lib/strings.toLower");
+    }
+
+    public static String apply(String upper) {
+        return upper.toLowerCase(); // TODO: Java's built-in behavior may not agree with that of Haskell or other host languages
+    }
+}

--- a/hydra-java/src/main/java/hydra/lib/strings/ToUpper.java
+++ b/hydra-java/src/main/java/hydra/lib/strings/ToUpper.java
@@ -1,0 +1,14 @@
+package hydra.lib.strings;
+
+import hydra.core.Name;
+import hydra.PrimitiveFunction;
+
+public class ToUpper<M> extends PrimitiveFunction<M> {
+    public Name name() {
+        return new Name("hydra/lib/strings.toUpper");
+    }
+
+    public static String apply(String lower) {
+        return lower.toUpperCase(); // TODO: Java's built-in behavior may not agree with that of Haskell or other host languages
+    }
+}

--- a/hydra-java/src/test/java/hydra/dsl/TermsTest.java
+++ b/hydra-java/src/test/java/hydra/dsl/TermsTest.java
@@ -3,6 +3,7 @@ package hydra.dsl;
 import hydra.core.Elimination;
 import hydra.core.Function;
 import hydra.core.Term;
+import hydra.dsl.prims.Strings;
 import hydra.core.Name;
 import org.junit.jupiter.api.Test;
 
@@ -36,10 +37,8 @@ public class TermsTest {
    */
   private final Term<String> stringLength = primitive("hydra/lib/strings.length");
 
-  private final Term<String> stringCat = primitive("hydra/lib/strings.cat");
-
   private final Term<String> cat3 =
-      lambda("s1", lambda("s2", lambda("s3", apply(stringCat, list(variable("s1"), variable("s2"), variable("s3"))))));
+      lambda("s1", lambda("s2", lambda("s3", apply(Strings.cat(), list(variable("s1"), variable("s2"), variable("s3"))))));
 
   private final Term<String> longitude = projection("LatLon", "lon");
 
@@ -82,10 +81,10 @@ public class TermsTest {
     assertEquals(name("Location"), ((Term.Union<String>) bayAreaLocation).value.typeName);
     assertEquals(fieldName("latlon"), ((Term.Union<String>) bayAreaLocation).value.field.name);
 
-    assertTrue(stringLength instanceof Term.Function);
-    assertTrue(((Term.Function<String>) stringLength).value instanceof Function.Primitive);
+    assertTrue(Strings.length() instanceof Term.Function);
+    assertTrue(((Term.Function<Object>) Strings.length()).value instanceof Function.Primitive);
     assertEquals(name("hydra/lib/strings.length"),
-        ((Function.Primitive<String>) ((Term.Function<String>) stringLength).value).value);
+        ((Function.Primitive<Object>) ((Term.Function<Object>) Strings.length()).value).value);
 
     assertTrue(cat3 instanceof Term.Function);
     assertTrue(((Term.Function<String>) cat3).value instanceof Function.Lambda);

--- a/hydra-java/src/test/java/hydra/lib/StringsTest.java
+++ b/hydra-java/src/test/java/hydra/lib/StringsTest.java
@@ -5,53 +5,54 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static hydra.lib.strings.Strings.*;
+// import static hydra.dsl.prims.Strings.*;
+import hydra.lib.strings.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class StringsTest {
     @Test
     public void catIsCorrect() {
-        assertEquals("onetwothree", cat(Arrays.asList("one", "two", "three")));
-        assertEquals("one", cat(Arrays.asList("", "one", "", "")));
-        assertEquals("", cat(Collections.emptyList()));
+        assertEquals("onetwothree", Cat.apply(Arrays.asList("one", "two", "three")));
+        assertEquals("one", Cat.apply(Arrays.asList("", "one", "", "")));
+        assertEquals("", Cat.apply(Collections.emptyList()));
     }
 
     @Test
     public void lengthIsCorrect() {
-        assertEquals(0, length(""));
-        assertEquals(1, length("a"));
-        assertEquals(3, length("one"));
+        assertEquals(0, Length.apply(""));
+        assertEquals(1, Length.apply("a"));
+        assertEquals(3, Length.apply("one"));
     }
 
     @Test
     public void splitOnIsCorrect() {
-        assertEquals(Arrays.asList("Mi", "i", "ippi"), splitOn("ss", "Mississippi"));
-        assertEquals(Arrays.asList("", ""), splitOn("Mississippi", "Mississippi"));
+        assertEquals(Arrays.asList("Mi", "i", "ippi"), SplitOn.apply("ss", "Mississippi"));
+        assertEquals(Arrays.asList("", ""), SplitOn.apply("Mississippi", "Mississippi"));
 
-        assertEquals(Arrays.asList("one", "two", "three"), splitOn(" ", "one two three"));
-        assertEquals(Arrays.asList("", "one", "two", "three", ""), splitOn(" ", " one two three "));
-        assertEquals(Arrays.asList("", "", "one", "two", "three", ""), splitOn(" ", "  one two three "));
-        assertEquals(Arrays.asList("", "one two three "), splitOn("  ", "  one two three "));
+        assertEquals(Arrays.asList("one", "two", "three"), SplitOn.apply(" ", "one two three"));
+        assertEquals(Arrays.asList("", "one", "two", "three", ""), SplitOn.apply(" ", " one two three "));
+        assertEquals(Arrays.asList("", "", "one", "two", "three", ""), SplitOn.apply(" ", "  one two three "));
+        assertEquals(Arrays.asList("", "one two three "), SplitOn.apply("  ", "  one two three "));
 
-        assertEquals(Arrays.asList("", "a"), splitOn("aa", "aaa"));
+        assertEquals(Arrays.asList("", "a"), SplitOn.apply("aa", "aaa"));
 
-        assertEquals(Collections.singletonList(""), splitOn("a", ""));
+        assertEquals(Collections.singletonList(""), SplitOn.apply("a", ""));
 
-        assertEquals(Arrays.asList("", "a", "b", "c"), splitOn("", "abc"));
-        assertEquals(Collections.singletonList(""), splitOn("", ""));
+        assertEquals(Arrays.asList("", "a", "b", "c"), SplitOn.apply("", "abc"));
+        assertEquals(Collections.singletonList(""), SplitOn.apply("", ""));
     }
 
     @Test
     // TODO: test the behavior of toLower for extended characters. Currently, the implementation just inherits Java's String.toLower()
     public void toLowerIsCorrect() {
-        assertEquals("one two three", toLower("One TWO threE"));
-        assertEquals("abc123", toLower("AbC123"));
+        assertEquals("one two three", ToLower.apply("One TWO threE"));
+        assertEquals("abc123", ToLower.apply("AbC123"));
     }
 
     @Test
     // TODO: test the behavior of toUpper for extended characters. Currently, the implementation just inherits Java's String.toUpper()
     public void toUpperIsCorrect() {
-        assertEquals("ONE TWO THREE", toUpper("One TWO threE"));
-        assertEquals("ABC123", toUpper("AbC123"));
+        assertEquals("ONE TWO THREE", ToUpper.apply("One TWO threE"));
+        assertEquals("ABC123", ToUpper.apply("AbC123"));
     }
 }


### PR DESCRIPTION
One way to cut down on the complexity of adding primitive function implementations in Java. We need at a minimum, for each primitive: 1) an implementation, 2) the name and a convenient way of constructing a term from the name, and 3) the type signature. (1) and (2) are illustrated here. (3) is not yet.