### PR TITLE
Fix type annotations for Sets Java port

### DIFF
--- a/hydra-java/src/main/java/hydra/lib/sets/Contains.java
+++ b/hydra-java/src/main/java/hydra/lib/sets/Contains.java
@@ -10,7 +10,7 @@ public class Contains<A> extends PrimitiveFunction<A> {
         return new Name("hydra/lib/sets.contains");
     }
 
-    public static <A> Boolean apply(A elem, Set<A> arg) {
+    public static <B> Boolean apply(B elem, Set<B> arg) {
         return arg.contains(elem);
     }
 }

--- a/hydra-java/src/main/java/hydra/lib/sets/Empty.java
+++ b/hydra-java/src/main/java/hydra/lib/sets/Empty.java
@@ -11,7 +11,7 @@ public class Empty<A> extends PrimitiveFunction<A> {
         return new Name("hydra/lib/sets.empty");
     }
 
-    public static <A> Set<A> apply() {
+    public static <B> Set<B> apply() {
         return Collections.emptySet();
     }
 }

--- a/hydra-java/src/main/java/hydra/lib/sets/FromList.java
+++ b/hydra-java/src/main/java/hydra/lib/sets/FromList.java
@@ -12,7 +12,7 @@ public class FromList<A> extends PrimitiveFunction<A> {
         return new Name("hydra/lib/sets.fromList");
     }
 
-    public static <A> Set<A> apply(List<A> arg) {
+    public static <B> Set<B> apply(List<B> arg) {
         return new HashSet(arg);
     }
 }

--- a/hydra-java/src/main/java/hydra/lib/sets/Insert.java
+++ b/hydra-java/src/main/java/hydra/lib/sets/Insert.java
@@ -11,8 +11,8 @@ public class Insert<A> extends PrimitiveFunction<A> {
         return new Name("hydra/lib/sets.insert");
     }
 
-    public static <A> Set<A> apply(A elem, Set<A> arg) {
-        Set<A> newSet = new HashSet(arg);
+    public static <B> Set<B> apply(B elem, Set<B> arg) {
+        Set<B> newSet = new HashSet(arg);
         newSet.add(elem);
         return newSet;
     }

--- a/hydra-java/src/main/java/hydra/lib/sets/IsEmpty.java
+++ b/hydra-java/src/main/java/hydra/lib/sets/IsEmpty.java
@@ -10,7 +10,7 @@ public class IsEmpty<A> extends PrimitiveFunction<A> {
         return new Name("hydra/lib/sets.isEmpty");
     }
 
-    public static <A> Boolean apply(Set<A> arg) {
+    public static <B> Boolean apply(Set<B> arg) {
         return arg.isEmpty();
     }
 }

--- a/hydra-java/src/main/java/hydra/lib/sets/Map.java
+++ b/hydra-java/src/main/java/hydra/lib/sets/Map.java
@@ -7,12 +7,12 @@ import java.util.function.Function;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class Map<A, B> extends PrimitiveFunction<A> {
+public class Map<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/sets.map");
     }
 
-    public static <A, B> Set<B> apply(Function<A, B> mapping, Set<A> arg) {
+    public static <B, C> Set<C> apply(Function<B, C> mapping, Set<B> arg) {
         return arg.stream().map(mapping).collect(Collectors.toSet());
     }
 }

--- a/hydra-java/src/main/java/hydra/lib/sets/Remove.java
+++ b/hydra-java/src/main/java/hydra/lib/sets/Remove.java
@@ -11,8 +11,8 @@ public class Remove<A> extends PrimitiveFunction<A> {
         return new Name("hydra/lib/sets.remove");
     }
 
-    public static <A> Set<A> apply(A elem, Set<A> arg) {
-        Set<A> newSet = new HashSet(arg);
+    public static <B> Set<B> apply(B elem, Set<B> arg) {
+        Set<B> newSet = new HashSet(arg);
         newSet.remove(elem);
         return newSet;
     }

--- a/hydra-java/src/main/java/hydra/lib/sets/Singleton.java
+++ b/hydra-java/src/main/java/hydra/lib/sets/Singleton.java
@@ -11,8 +11,8 @@ public class Singleton<A> extends PrimitiveFunction<A> {
         return new Name("hydra/lib/sets.singleton");
     }
 
-    public static <A> Set<A> apply(A elem) {
-        Set<A> newSet = new HashSet();
+    public static <B> Set<B> apply(B elem) {
+        Set<B> newSet = new HashSet();
         newSet.add(elem);
         return newSet;
     }

--- a/hydra-java/src/main/java/hydra/lib/sets/Size.java
+++ b/hydra-java/src/main/java/hydra/lib/sets/Size.java
@@ -10,7 +10,7 @@ public class Size<A> extends PrimitiveFunction<A> {
         return new Name("hydra/lib/sets.size");
     }
 
-    public static <A> Integer apply(Set<A> arg) {
+    public static <B> Integer apply(Set<B> arg) {
         return arg.size();
     }
 }

--- a/hydra-java/src/main/java/hydra/lib/sets/ToList.java
+++ b/hydra-java/src/main/java/hydra/lib/sets/ToList.java
@@ -12,7 +12,7 @@ public class ToList<A> extends PrimitiveFunction<A> {
         return new Name("hydra/lib/sets.toList");
     }
 
-    public static <A> List<A> apply(Set<A> arg) {
+    public static <B> List<B> apply(Set<B> arg) {
         return new ArrayList(arg);
     }
 }


### PR DESCRIPTION
Fixes #48 

This module had some incorrect type annotations. In general, the class declaration should look like:

```
public class MyFunc<A> extends PrimitiveFunction<A>
```

And typeclass A should not be used anywhere else within the class. This is because A is only meant to act as an annotation to help convert the function into a Term.