### PR TITLE
[hydra-java] Implement partial application for math lib

### DIFF
--- a/hydra-java/src/main/java/hydra/lib/math/Add.java
+++ b/hydra-java/src/main/java/hydra/lib/math/Add.java
@@ -3,12 +3,18 @@ package hydra.lib.math;
 import hydra.core.Name;
 import hydra.util.PrimitiveFunction;
 
+import java.util.function.Function;
+
 public class Add<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/math.add");
     }
 
+    public static Function<Integer, Integer> apply(Integer augend) {
+        return (addend) -> augend + addend;
+    }
+
     public static Integer apply(Integer augend, Integer addend) {
-        return (augend + addend);
+        return Add.apply(augend).apply(addend);
     }
 }

--- a/hydra-java/src/main/java/hydra/lib/math/Div.java
+++ b/hydra-java/src/main/java/hydra/lib/math/Div.java
@@ -3,12 +3,18 @@ package hydra.lib.math;
 import hydra.core.Name;
 import hydra.util.PrimitiveFunction;
 
+import java.util.function.Function;
+
 public class Div<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/math.div");
     }
 
+    public static Function<Integer, Integer> apply(Integer dividend) {
+        return (divisor) -> dividend / divisor;
+    }
+
     public static Integer apply(Integer dividend, Integer divisor) {
-        return (dividend / divisor);
+        return Div.apply(dividend).apply(divisor);
     }
 }

--- a/hydra-java/src/main/java/hydra/lib/math/Mod.java
+++ b/hydra-java/src/main/java/hydra/lib/math/Mod.java
@@ -3,12 +3,18 @@ package hydra.lib.math;
 import hydra.core.Name;
 import hydra.util.PrimitiveFunction;
 
+import java.util.function.Function;
+
 public class Mod<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/math.mod");
     }
 
+    public static Function<Integer, Integer> apply(Integer dividend) {
+        return (divisor) -> java.lang.Math.floorMod(dividend, divisor);
+    }
+
     public static Integer apply(Integer dividend, Integer divisor) {
-        return java.lang.Math.floorMod(dividend, divisor);
+        return Mod.apply(dividend).apply(divisor);
     }
 }

--- a/hydra-java/src/main/java/hydra/lib/math/Mul.java
+++ b/hydra-java/src/main/java/hydra/lib/math/Mul.java
@@ -3,12 +3,18 @@ package hydra.lib.math;
 import hydra.core.Name;
 import hydra.util.PrimitiveFunction;
 
+import java.util.function.Function;
+
 public class Mul<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/math.mul");
     }
 
+    public static Function<Integer, Integer> apply(Integer multiplier) {
+        return (multiplicand) -> multiplier * multiplicand;
+    }
+
     public static Integer apply(Integer multiplier, Integer multiplicand) {
-        return (multiplier * multiplicand);
+        return Mul.apply(multiplier).apply(multiplicand);
     }
 }

--- a/hydra-java/src/main/java/hydra/lib/math/Neg.java
+++ b/hydra-java/src/main/java/hydra/lib/math/Neg.java
@@ -3,6 +3,8 @@ package hydra.lib.math;
 import hydra.core.Name;
 import hydra.util.PrimitiveFunction;
 
+import java.util.function.Function;
+
 public class Neg<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/math.neg");

--- a/hydra-java/src/main/java/hydra/lib/math/Rem.java
+++ b/hydra-java/src/main/java/hydra/lib/math/Rem.java
@@ -3,13 +3,19 @@ package hydra.lib.math;
 import hydra.core.Name;
 import hydra.util.PrimitiveFunction;
 
+import java.util.function.Function;
+
 public class Rem<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/math.rem");
     }
 
-    public static Integer apply(Integer dividend, Integer divisor) {
+    public static Function<Integer, Integer> apply(Integer dividend) {
         // % in Java is a mathematical remainder, not modulus
-        return (dividend % divisor);
+        return (divisor) -> dividend % divisor;
+    }
+
+    public static Integer apply(Integer dividend, Integer divisor) {
+        return Rem.apply(dividend).apply(divisor);
     }
 }

--- a/hydra-java/src/main/java/hydra/lib/math/Sub.java
+++ b/hydra-java/src/main/java/hydra/lib/math/Sub.java
@@ -3,12 +3,18 @@ package hydra.lib.math;
 import hydra.core.Name;
 import hydra.util.PrimitiveFunction;
 
+import java.util.function.Function;
+
 public class Sub<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/math.sub");
     }
 
-    public static Integer add(Integer minuend, Integer subtrahend) {
-        return (minuend - subtrahend);
+    public static Function<Integer, Integer> apply(Integer minuend) {
+        return (subtrahend) -> minuend - subtrahend;
+    }
+
+    public static Integer apply(Integer minuend, Integer subtrahend) {
+        return Sub.apply(minuend).apply(subtrahend);
     }
 }


### PR DESCRIPTION
This commit allows for partial application of the primitive functions in the math library. In other words, currying.

You can call `apply` with any number of arguments (up to the maximum defined for a function), and receive one of the following return types:
- If you provided all arguments, then you simply get the function's defined return value.
- If you provided a subset of arguments, then you get a function that takes the second argument and returns the final value.