### PR TITLE
[hydra-java] Update math lib partial function application style

### DIFF
--- a/hydra-java/src/main/java/hydra/lib/math/Add.java
+++ b/hydra-java/src/main/java/hydra/lib/math/Add.java
@@ -3,18 +3,12 @@ package hydra.lib.math;
 import hydra.core.Name;
 import hydra.util.PrimitiveFunction;
 
-import java.util.function.Function;
-
 public class Add<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/math.add");
     }
 
-    public static Function<Integer, Integer> apply(Integer augend) {
-        return (addend) -> augend + addend;
-    }
-
     public static Integer apply(Integer augend, Integer addend) {
-        return Add.apply(augend).apply(addend);
+        return (augend + addend);
     }
 }

--- a/hydra-java/src/main/java/hydra/lib/math/Add.java
+++ b/hydra-java/src/main/java/hydra/lib/math/Add.java
@@ -3,9 +3,15 @@ package hydra.lib.math;
 import hydra.core.Name;
 import hydra.util.PrimitiveFunction;
 
+import java.util.function.Function;
+
 public class Add<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/math.add");
+    }
+
+    public static Function<Integer, Integer> apply(Integer augend) {
+        return (addend) -> apply(augend, addend);
     }
 
     public static Integer apply(Integer augend, Integer addend) {

--- a/hydra-java/src/main/java/hydra/lib/math/Div.java
+++ b/hydra-java/src/main/java/hydra/lib/math/Div.java
@@ -3,18 +3,12 @@ package hydra.lib.math;
 import hydra.core.Name;
 import hydra.util.PrimitiveFunction;
 
-import java.util.function.Function;
-
 public class Div<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/math.div");
     }
 
-    public static Function<Integer, Integer> apply(Integer dividend) {
-        return (divisor) -> dividend / divisor;
-    }
-
     public static Integer apply(Integer dividend, Integer divisor) {
-        return Div.apply(dividend).apply(divisor);
+        return (dividend / divisor);
     }
 }

--- a/hydra-java/src/main/java/hydra/lib/math/Div.java
+++ b/hydra-java/src/main/java/hydra/lib/math/Div.java
@@ -3,9 +3,15 @@ package hydra.lib.math;
 import hydra.core.Name;
 import hydra.util.PrimitiveFunction;
 
+import java.util.function.Function;
+
 public class Div<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/math.div");
+    }
+
+    public static Function<Integer, Integer> apply(Integer dividend) {
+        return (divisor) -> apply(dividend, divisor);
     }
 
     public static Integer apply(Integer dividend, Integer divisor) {

--- a/hydra-java/src/main/java/hydra/lib/math/Mod.java
+++ b/hydra-java/src/main/java/hydra/lib/math/Mod.java
@@ -3,9 +3,15 @@ package hydra.lib.math;
 import hydra.core.Name;
 import hydra.util.PrimitiveFunction;
 
+import java.util.function.Function;
+
 public class Mod<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/math.mod");
+    }
+
+    public static Function<Integer, Integer> apply(Integer dividend) {
+        return (divisor) -> apply(dividend, divisor);
     }
 
     public static Integer apply(Integer dividend, Integer divisor) {

--- a/hydra-java/src/main/java/hydra/lib/math/Mod.java
+++ b/hydra-java/src/main/java/hydra/lib/math/Mod.java
@@ -3,18 +3,12 @@ package hydra.lib.math;
 import hydra.core.Name;
 import hydra.util.PrimitiveFunction;
 
-import java.util.function.Function;
-
 public class Mod<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/math.mod");
     }
 
-    public static Function<Integer, Integer> apply(Integer dividend) {
-        return (divisor) -> java.lang.Math.floorMod(dividend, divisor);
-    }
-
     public static Integer apply(Integer dividend, Integer divisor) {
-        return Mod.apply(dividend).apply(divisor);
+        return java.lang.Math.floorMod(dividend, divisor);
     }
 }

--- a/hydra-java/src/main/java/hydra/lib/math/Mul.java
+++ b/hydra-java/src/main/java/hydra/lib/math/Mul.java
@@ -3,18 +3,12 @@ package hydra.lib.math;
 import hydra.core.Name;
 import hydra.util.PrimitiveFunction;
 
-import java.util.function.Function;
-
 public class Mul<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/math.mul");
     }
 
-    public static Function<Integer, Integer> apply(Integer multiplier) {
-        return (multiplicand) -> multiplier * multiplicand;
-    }
-
     public static Integer apply(Integer multiplier, Integer multiplicand) {
-        return Mul.apply(multiplier).apply(multiplicand);
+        return (multiplier * multiplicand);
     }
 }

--- a/hydra-java/src/main/java/hydra/lib/math/Mul.java
+++ b/hydra-java/src/main/java/hydra/lib/math/Mul.java
@@ -3,9 +3,15 @@ package hydra.lib.math;
 import hydra.core.Name;
 import hydra.util.PrimitiveFunction;
 
+import java.util.function.Function;
+
 public class Mul<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/math.mul");
+    }
+
+    public static Function<Integer, Integer> apply(Integer multiplier) {
+        return (multiplicand) -> apply(multiplier, multiplicand);
     }
 
     public static Integer apply(Integer multiplier, Integer multiplicand) {

--- a/hydra-java/src/main/java/hydra/lib/math/Neg.java
+++ b/hydra-java/src/main/java/hydra/lib/math/Neg.java
@@ -3,8 +3,6 @@ package hydra.lib.math;
 import hydra.core.Name;
 import hydra.util.PrimitiveFunction;
 
-import java.util.function.Function;
-
 public class Neg<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/math.neg");

--- a/hydra-java/src/main/java/hydra/lib/math/Rem.java
+++ b/hydra-java/src/main/java/hydra/lib/math/Rem.java
@@ -3,19 +3,13 @@ package hydra.lib.math;
 import hydra.core.Name;
 import hydra.util.PrimitiveFunction;
 
-import java.util.function.Function;
-
 public class Rem<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/math.rem");
     }
 
-    public static Function<Integer, Integer> apply(Integer dividend) {
-        // % in Java is a mathematical remainder, not modulus
-        return (divisor) -> dividend % divisor;
-    }
-
     public static Integer apply(Integer dividend, Integer divisor) {
-        return Rem.apply(dividend).apply(divisor);
+        // % in Java is a mathematical remainder, not modulus
+        return (dividend % divisor);
     }
 }

--- a/hydra-java/src/main/java/hydra/lib/math/Rem.java
+++ b/hydra-java/src/main/java/hydra/lib/math/Rem.java
@@ -3,9 +3,15 @@ package hydra.lib.math;
 import hydra.core.Name;
 import hydra.util.PrimitiveFunction;
 
+import java.util.function.Function;
+
 public class Rem<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/math.rem");
+    }
+
+    public static Function<Integer, Integer> apply(Integer dividend) {
+        return (divisor) -> apply(dividend, divisor);
     }
 
     public static Integer apply(Integer dividend, Integer divisor) {

--- a/hydra-java/src/main/java/hydra/lib/math/Sub.java
+++ b/hydra-java/src/main/java/hydra/lib/math/Sub.java
@@ -3,12 +3,18 @@ package hydra.lib.math;
 import hydra.core.Name;
 import hydra.util.PrimitiveFunction;
 
+import java.util.function.Function;
+
 public class Sub<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/math.sub");
     }
 
-    public static Integer add(Integer minuend, Integer subtrahend) {
+    public static Function<Integer, Integer> apply(Integer minuend) {
+        return (subtrahend) -> apply(minuend, subtrahend);
+    }
+
+    public static Integer apply(Integer minuend, Integer subtrahend) {
         return (minuend - subtrahend);
     }
 }

--- a/hydra-java/src/main/java/hydra/lib/math/Sub.java
+++ b/hydra-java/src/main/java/hydra/lib/math/Sub.java
@@ -3,18 +3,12 @@ package hydra.lib.math;
 import hydra.core.Name;
 import hydra.util.PrimitiveFunction;
 
-import java.util.function.Function;
-
 public class Sub<A> extends PrimitiveFunction<A> {
     public Name name() {
         return new Name("hydra/lib/math.sub");
     }
 
-    public static Function<Integer, Integer> apply(Integer minuend) {
-        return (subtrahend) -> minuend - subtrahend;
-    }
-
-    public static Integer apply(Integer minuend, Integer subtrahend) {
-        return Sub.apply(minuend).apply(subtrahend);
+    public static Integer add(Integer minuend, Integer subtrahend) {
+        return (minuend - subtrahend);
     }
 }


### PR DESCRIPTION
This commit puts the function implementation in the fully unrolled `apply` definition, as opposed to the partially-applied definition. Making this change helps in two ways:
1. The code is cleaner.
2. We avoid calling multiple functions when invoking the fully-unrolled `apply`.