### PR TITLE
Fix a bug in Flows.java: modifying immutable Collections.emptySet()

### DIFF
--- a/hydra-java/src/main/java/hydra/Flows.java
+++ b/hydra-java/src/main/java/hydra/Flows.java
@@ -9,6 +9,7 @@ import hydra.tools.TriFunction;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -161,7 +162,7 @@ public interface Flows {
      * Map a monadic function over a set, producing a flow of sets
      */
     static <S, X, Y> Flow<S, Set<Y>> mapM(Set<X> xs, Function<X, Flow<S, Y>> f) {
-        Flow<S, Set<Y>> result = pure(Collections.emptySet());
+        Flow<S, Set<Y>> result = pure(new HashSet<>(xs.size()));
         for (X x : xs) {
             result = bind(result, ys -> map(f.apply(x), y -> {
                 ys.add(y); // Modify in place


### PR DESCRIPTION
`mapM` method is calling `add()` on `Collections.emptySet()`, which is immutable. See https://docs.oracle.com/javase/8/docs/api/java/util/Collections.html#emptySet--. The exception below occurred when using the `mapM` method for `Map`:
```
java.lang.UnsupportedOperationException
        at java.base/java.util.AbstractCollection.add(AbstractCollection.java:251)
        at hydra.Flows.lambda$mapM$21(Flows.java:118)
        at java.base/java.util.Optional.map(Optional.java:260)
        at hydra.Flows.lambda$map$11(Flows.java:84)
        at hydra.Flows.lambda$bind$2(Flows.java:41)
        at hydra.Flows.lambda$bind$2(Flows.java:38)
        at hydra.Flows.lambda$bind$2(Flows.java:38)
        at hydra.Flows.lambda$map$11(Flows.java:83)
        at hydra.Flows.lambda$bind$2(Flows.java:38)
        at hydra.Flows.lambda$bind$2(Flows.java:41)
        at hydra.Flows.lambda$bind$2(Flows.java:41)
        at hydra.HydraTestBase.assertSucceedsWith(HydraTestBase.java:60)
        at hydra.HydraTestBase.assertSucceedsWith(HydraTestBase.java:56)
        at com.linkedin.agm.galgos.graphs.coders.GraphVertexCoderTest.testEncode(GraphVertexCoderTest.java:50)
```
Initializing empty Set using `HashSet` to fix the issue.