### PR TITLE
Fixup 459 seed guard dryrun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,15 +123,13 @@ jobs:
       # and dist/<lang>/ for every target from the JSON (Phase 2,
       # per-package). Any drift from the committed dist/json/ or
       # dist/haskell/ tree fails the job.
-      # GENERATOR_HOST pinned to haskell (#459): this job's default Gradle heap is too
-      # small for :hydra-java:compileJava under the all-hosts x all-targets cross
-      # product (OutOfMemoryError on run 30748429237). GENERATOR_HOST=java is the
-      # default for normal/local use — pin back to haskell here until CI's Gradle heap
-      # is sized for the Java generator (see assemble-common.sh's own comment on this
-      # exact fallback).
+      # #459 dry-run: GENERATOR_HOST left UNPINNED so this job runs the java-default
+      # generator and exercises the circular-seed guard (assemble-common.sh's
+      # run_layer1_transform forces hydra-build's java-target seed through haskell-gen,
+      # avoiding the target-driver from-source :hydra-java compile that OOM'd/timed out
+      # in PR #627). This proves the guard lets the cheap bytecode path run within CI's
+      # budget without the 10g heap bump PR #627 needed.
       - name: Regenerate JSON and all target dists from DSL sources
-        env:
-          GENERATOR_HOST: haskell
         run: |
           bin/sync.sh --hosts all --targets all --no-tests
       # The bootstrapping matrix above intentionally skips the "on-
@@ -408,13 +406,11 @@ jobs:
       # sentinel check is satisfied and the rest of the pipeline runs exactly
       # as it would on a warm tree — proving the seeded output is not just
       # present but actually consumable by the full head build + test suite.
-      # GENERATOR_HOST pinned to haskell (#459): run_layer1_transform dispatches on
-      # GENERATOR_HOST regardless of --hosts/--targets, so even a haskell-only sync
-      # would route through the Java generator under this job's default (too-small)
-      # Gradle heap. See the "Regenerate JSON and all target dists" step above.
+      # #459 dry-run: GENERATOR_HOST left UNPINNED (see the "Regenerate JSON and all
+      # target dists" step above). run_layer1_transform dispatches on GENERATOR_HOST
+      # regardless of --hosts/--targets, so even this haskell-only sync routes through
+      # the Java generator — exercising the circular-seed guard on the hydra-build seed.
       - name: Full sync + stack test from the seeded tree
-        env:
-          GENERATOR_HOST: haskell
         run: bin/sync.sh --hosts haskell --targets haskell
       # Regression check: a full sync must never leave dist/haskell/ tracked
       # or trackable again. Checked AFTER the full sync above (not just after

--- a/bin/lib/assemble-common.sh
+++ b/bin/lib/assemble-common.sh
@@ -367,9 +367,29 @@ assemble_refresh_digest() {
 # sync.sh pass (e.g. to fall back for a target the Java host does not yet emit correctly).
 #
 # Usage: run_layer1_transform <target> <pkg> [main|test] [OPTIONS...]
+#
+# #459 circular-seed guard: the Java generator (target-driver) compiles hydra.build.*
+# from dist/java/hydra-build/src (target-driver/build.gradle srcDirs it; hydra-build has
+# NO published Maven artifact, so it cannot come from the jar). That makes generating the
+# `java` dist of `hydra-build` itself circular under the java-default: the driver needs the
+# very output it is being asked to produce, so on a cold checkout its compileJava fails and
+# the pipeline falls back to a ~4h from-source :hydra-java build (the #459 dry-run timeout).
+# hydra-build is the SOLE non-published, self-referential seed. Force its java-target
+# generation through the Haskell generator (which srcDirs NEITHER target-driver NOR
+# dist/java/hydra-build — a non-circular seed), regardless of GENERATOR_HOST. This is exactly
+# the "run one package via Haskell in the same pass" fallback the per-invocation contract
+# above allows, and it keeps the java-default's bytecode win for every other (non-circular)
+# package. Scoped to target=java because only the Java drivers (target-driver, json-driver)
+# srcDir dist/java/hydra-build; other targets have no such dependency.
 run_layer1_transform() {
     local target="$1"
-    case "${GENERATOR_HOST:-java}" in
+    local pkg="${2:-}"
+    local effective_host="${GENERATOR_HOST:-java}"
+    if [ "$effective_host" = "java" ] && [ "$target" = "java" ] && [ "$pkg" = "hydra-build" ]; then
+        echo "run_layer1_transform: seeding java/hydra-build via Haskell generator (#459 circular-seed guard)" >&2
+        effective_host="haskell"
+    fi
+    case "$effective_host" in
         java)
             "$HYDRA_ROOT_DIR/heads/java/bin/transform-json-to-target.sh" "$@"
             ;;


### PR DESCRIPTION
# Pull request

## What does this change?

A short description of the change and the motivation. Link the issue it addresses
(e.g. `For #123` / `Resolves #123`).

## How was it tested?

- [ ] `stack test` passes in `heads/haskell` (required for any kernel/DSL change)
- [ ] Affected target-language tests pass (`bin/test.sh <langs>` or the per-head test scripts)
- [ ] Regenerated code is included if DSL sources changed (`bin/sync.sh` or a scoped wrapper)

## Checklist (core expectations — see [CONTRIBUTING.md](../CONTRIBUTING.md))

- [ ] No hand-edits to generated files under `dist/` — generator or DSL fixes only
- [ ] No failing tests skipped or worked around
- [ ] Change is focused; unrelated cleanups are in separate commits
- [ ] Follows the [coding style](https://github.com/CategoricalData/hydra/wiki/Coding-style)
      (including alphabetical ordering of DSL definitions lists)
- [ ] User-facing behavior changes are documented (README, docs/, or wiki)
